### PR TITLE
Add SMA8S.gltf to radar materials

### DIFF
--- a/materials/SMA8S.gltf
+++ b/materials/SMA8S.gltf
@@ -6,12 +6,12 @@
         "extensions": {
             "OpenMaterial_asset_info": {
                 "asset_type": "material",
-                "id": "",
+                "id": "e416b969-5c8d-41ee-a6cf-b4630c8c76a4",
                 "title": "material_SMA8S",
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "  material",
+                "description": "material SMA8S: abbreviation for split mastix asphalt with a maximum grain size of 8mm",
                 "creation_date": "2022.01.26. 14:48:00"
             }
         }
@@ -41,7 +41,7 @@
                         "lambert_emission": 0.0,
                         "subsurface": {
                             "subsurface": false,
-                            "subsurface_thickness": xxx
+                            "subsurface_thickness": -1.0
                         },
                         "ingredients": [
                             {
@@ -57,11 +57,11 @@
                         ] 
                     },
                     "physical_properties": {
-                        "refractive_index_uri": "",
+                        "refractive_index_uri": -1.0,
                         "mean_free_path": 1E-06,
                         "particle_density": 2.7,
                         "particle_cross_section": 1.00E+0,
-                        "emissive_coefficient_uri": "",
+                        "emissive_coefficient_uri": -1.0,
                         "detection_wavelength_ranges": [
                         {
                                 "min": 300E-09,
@@ -89,12 +89,12 @@
                             "radar",
                             "lidar"
                         ],
-                        "effective_particle_area": xxx,
+                        "effective_particle_area": -1.0,
                         "relative_permittivity_uri": "data/SMA8S_permittivity.gltf",
-                        "relative_permeability_uri" : "",
-                        "electrical_resistivity": xxx,
-                        "acoustic_impedance":xxx,
-                        "shear_velocity": xxx 
+                        "relative_permeability_uri" : -1.0,
+                        "electrical_resistivity": -1.0,
+                        "acoustic_impedance":-1.0,
+                        "shear_velocity": -1.0 
                     }
                 }
             }

--- a/materials/SMA8S.gltf
+++ b/materials/SMA8S.gltf
@@ -1,0 +1,107 @@
+  {
+    "asset": {
+        "copyright" : "(C) 2019, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)",
+        "generator": "Khronos Blender glTF 2.0 I/O",
+        "version": "1.0",
+        "extensions": {
+            "OpenMaterial_asset_info": {
+                "asset_type": "material",
+                "id": "",
+                "title": "material_SMA8S",
+                "asset_version": "1",
+                "asset_variation": "1",
+                "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
+                "description": "  material",
+                "creation_date": "2022.01.26. 14:48:00"
+            }
+        }
+    },
+    "materials": [
+        {
+            "name": "SMA8S",
+            "extensions": {
+                "OpenMaterial_material_parameters": {
+                    "user_preferences": {
+                        "geometrical_optics": true,
+                        "include_diffraction": false,
+                        "include_numerical_simulation": false,
+                        "material_scheme": "surface",
+                        "material_classification": "road_surface",
+                        "material_type": {
+                            "isotropic": true,
+                            "homogeneous": false,
+                            "magnetic": false
+                        },
+                        "temperature": 280.0,
+                        "surface_displacement_uri": "surface_uri",
+                        "surface_roughness": {
+                            "surface_height": 800,
+                            "surface_correlation_length": 1.0
+                        },
+                        "lambert_emission": 0.0,
+                        "subsurface": {
+                            "subsurface": false,
+                            "subsurface_thickness": xxx
+                        },
+                        "ingredients": [
+                            {
+                            "material_ref": "ingredients.gltf",
+                            "order": "order.glft"
+                            }
+                        ],
+						"coating_materials": [
+                            {
+                            "layer_thickness": 0.0,
+                            "material_ref": "coating.gltf"
+                            }
+                        ] 
+                    },
+                    "physical_properties": {
+                        "refractive_index_uri": "",
+                        "mean_free_path": 1E-06,
+                        "particle_density": 2.7,
+                        "particle_cross_section": 1.00E+0,
+                        "emissive_coefficient_uri": "",
+                        "detection_wavelength_ranges": [
+                        {
+                                "min": 300E-09,
+                                "max": 800E-09,
+                                "typical_sensor": "camera"
+                            },
+                            {
+                                "min": 0.001,
+                                "max": 100,
+                                "typical_sensor": "radar"
+                            },
+                            {
+                                "min": 200E-09,
+                                "max": 1700E-09,
+                                "typical_sensor": "lidar"
+                            },
+                            {
+                                "min": 100,
+                                "max": 15000,
+                                "typical_sensor": "ultrasound"
+                            }
+                        ],
+                        "applicable_sensors": [
+                            "camera",
+                            "radar",
+                            "lidar"
+                        ],
+                        "effective_particle_area": xxx,
+                        "relative_permittivity_uri": "data/SMA8S_permittivity.gltf",
+                        "relative_permeability_uri" : "",
+                        "electrical_resistivity": xxx,
+                        "acoustic_impedance":xxx,
+                        "shear_velocity": xxx 
+                    }
+                }
+            }
+        }
+    ],
+    "extensionsUsed": [
+        "OpenMaterial_asset_info",
+        "OpenMaterial_material_parameters"
+    ]
+}

--- a/materials/SMA8S.gltf
+++ b/materials/SMA8S.gltf
@@ -11,7 +11,7 @@
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "material SMA8S: abbreviation for split mastix asphalt with a maximum grain size of 8mm",
+                "description": "common road surface material SMA8S: abbreviation for split mastix asphalt with a maximum grain size of 8mm",
                 "creation_date": "2022.01.26. 14:48:00"
             }
         }
@@ -57,11 +57,11 @@
                         ] 
                     },
                     "physical_properties": {
-                        "refractive_index_uri": -1.0,
+                        "refractive_index_uri": "",
                         "mean_free_path": 1E-06,
                         "particle_density": 2.7,
                         "particle_cross_section": 1.00E+0,
-                        "emissive_coefficient_uri": -1.0,
+                        "emissive_coefficient_uri": "",
                         "detection_wavelength_ranges": [
                         {
                                 "min": 300E-09,
@@ -91,7 +91,7 @@
                         ],
                         "effective_particle_area": -1.0,
                         "relative_permittivity_uri": "data/SMA8S_permittivity.gltf",
-                        "relative_permeability_uri" : -1.0,
+                        "relative_permeability_uri" : "",
                         "electrical_resistivity": -1.0,
                         "acoustic_impedance":-1.0,
                         "shear_velocity": -1.0 


### PR DESCRIPTION
SMA8S: abbreviation for split mastix asphalt with maximum grain size of 8mm