### PR TITLE
Add humidty to permeability and permittivity extensions

### DIFF
--- a/glTF_extensions/OpenMaterial_permeability_data/README.md
+++ b/glTF_extensions/OpenMaterial_permeability_data/README.md
@@ -2,7 +2,7 @@ OpenMaterial_permeability_data
 ==============================
 
 This is a proposal for an extension to the [Khronos Group glTF 2.0](https://github.com/KhronosGroup/glTF) specification. The goal of this extension is to
-provide a physically accurate description of the relative permeability at a given temperature, incident angle
+provide a physically accurate description of the relative permeability at a given temperature, humidity, incident angle
 and wavelength range in a look-up table. Values within the range which aren't explicitly listed can be
 obtained using linear interpolation.
 
@@ -21,13 +21,15 @@ file:
 Properties
 ----------
 
-This extension provides relative permeability data measured at a certain incident angle and temperature for a certain wavelenght range.
+This extension provides relative permeability data measured at a certain incident angle, temperature and humidity for a certain wavelenght range.
 
 Within the following enlistment of properties specified by the proposed extension, items labeled as **required** are
 mandatory and must be present. Properties without **required** label are optional and may be omitted:
 
 * **`temperature`** [number][**required**]
-Temperature [K] at which an permeability value was measured.
+Temperature [K] at which permeability was measured.
+* **`relative_humidity`** [number][**required**]
+Relative humidity [%] at which permeability was measured.
 * **`incident_angle`** [number][**required**]
 Incident angle of the measurement relative to the local normal vector at the material surface in [rad].
 * **`permeability`** [number][**required**]
@@ -67,6 +69,7 @@ The permeability data file (in this case `tarmac_permeability.gltf`) provides th
         "data": [
             {
                 "temperature": 300.0,
+                "humidity": 80.0,
                 "incident_angle": 0.785398,				
                 "permeability": [
                     [3.89341e-03, xxx]

--- a/glTF_extensions/OpenMaterial_permeability_data/schema/OpenMaterial_permeability_data.schema.json
+++ b/glTF_extensions/OpenMaterial_permeability_data/schema/OpenMaterial_permeability_data.schema.json
@@ -1,18 +1,22 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Proposed OpenMaterial_permeability_data glTF extension",
-    "description": "Measured relative permeability at given temperature and incident angle.",
+    "description": "Measured relative permeability at given temperature, humidity and incident angle.",
     "type": "object",
     "patternProperties": {
         "data": {
             "type": "array",
-            "description": "Measured reltative permeability at specific temperature and incident angle.",
+            "description": "Measured relative permeability at specific temperature, humidity and incident angle.",
             "items": {
                 "type": "object",
-                "description": "Array of permeability at given wavelength, specific temperature and incident angle.",
+                "description": "Array of permeability at given wavelength, specific temperature, humidity and incident angle.",
                 "properties": {
                     "temperature": {
                         "description": "Temperature [K] (T(°C) = T(K) - 273.15).",
+                        "type": "number"
+                    },
+                    "humidity": {
+                        "description": "Relative humidity [%].",
                         "type": "number"
                     },
                     "incident_angle": {
@@ -39,6 +43,7 @@
                 },
                 "required": [
                     "temperature",
+                    "humidity",
                     "incident_angle",
                     "permeability"
                 ]

--- a/glTF_extensions/OpenMaterial_permittivity_data/README.md
+++ b/glTF_extensions/OpenMaterial_permittivity_data/README.md
@@ -2,7 +2,7 @@ OpenMaterial_permittivity_data
 ==============================
 
 This is a proposal for an extension to the [Khronos Group glTF 2.0](https://github.com/KhronosGroup/glTF) specification. The goal of this extension is to
-provide a physically accurate description of the relative permittivity at a given temperature, incident angle
+provide a physically accurate description of the relative permittivity at a given temperature, humidity, incident angle
 and wavelength range in a look-up table. Values within the range which aren't explicitly listed can be
 obtained using linear interpolation.
 
@@ -21,13 +21,15 @@ file:
 Properties
 ----------
 
-This extension provides relative permittivity data measured at a certain incident angle and temperature for a certain wavelenght range.
+This extension provides relative permittivity data measured at a certain incident angle, temperature and humidity for a certain wavelenght range.
 
 Within the following enlistment of properties specified by the proposed extension, items labeled as **required** are
 mandatory and must be present. Properties without **required** label are optional and may be omitted:
 
 * **`temperature`** [number][**required**]
-Temperature [K] at which an permittivity value was measured.
+Temperature [K] at which permittivity was measured.
+* **`relative_humidity`** [number][**required**]
+Relative humidity [%] at which permeability was measured.
 * **`incident_angle`** [number][**required**]
 Incident angle of the measurement relative to the local normal vector at the material surface in [rad].
 * **`permittivity`** [number][**required**]
@@ -67,6 +69,7 @@ The permittivity data file (in this case `tarmac_permittivity.gltf`) provides th
         "data": [
             {
                 "temperature": 300.0,
+                "humidity": 80.0,
                 "incident_angle": 0.785398,				
                 "permittivity": [
                     [3.89341e-03, xxx]

--- a/glTF_extensions/OpenMaterial_permittivity_data/schema/OpenMaterial_permittivity_data.schema.json
+++ b/glTF_extensions/OpenMaterial_permittivity_data/schema/OpenMaterial_permittivity_data.schema.json
@@ -1,18 +1,22 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Proposed OpenMaterial_permittivity_data glTF extension",
-    "description": "Measured relative permittivity at given temperature and incident angle.",
+    "description": "Measured relative permittivity at given temperature, humidity and incident angle.",
     "type": "object",
     "patternProperties": {
         "data": {
             "type": "array",
-            "description": "Measured reltative permittivity at specific temperature and incident angle.",
+            "description": "Measured relative permittivity at specific temperature, humidity and incident angle.",
             "items": {
                 "type": "object",
-                "description": "Array of permittivity at given wavelength, specific temperature and incident angle.",
+                "description": "Array of permittivity at given wavelength, specific temperature, humidity and incident angle.",
                 "properties": {
                     "temperature": {
                         "description": "Temperature [K] (T(°C) = T(K) - 273.15).",
+                        "type": "number"
+                    },
+                    "humidity": {
+                        "description": "Relative humidity [%].",
                         "type": "number"
                     },
                     "incident_angle": {
@@ -39,6 +43,7 @@
                 },
                 "required": [
                     "temperature",
+                    "humidity",
                     "incident_angle",
                     "permittivity"
                 ]

--- a/glTF_extensions/README.md
+++ b/glTF_extensions/README.md
@@ -4,12 +4,12 @@ Proposed glTF Extensions
 This directory contains the following proposals for extensions to the [Khronos Group glTF 2.0](https://github.com/KhronosGroup/glTF) file format:
 
 | Filepath                                                                | Description
-|:------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------|
-| [`OpenMaterial_asset_info`](OpenMaterial_asset_info/)                   | Proposed extension defining properties for assets                                                    |
-| [`OpenMaterial_conductivity_data`](OpenMaterial_conductivity_data/)     | Proposed extension providing conductivity values for a given temperature and wavelength range        |
-| [`OpenMaterial_emissivity_data`](OpenMaterial_emissivity_data/)         | Proposed extension providing emissivity coefficient values for a given temperature                   |
-| [`OpenMaterial_ior_data`](OpenMaterial_ior_data/)                       | Proposed extension providing index of refraction values for a given temperature and wavelength range |
-| [`OpenMaterial_permeability_data`](OpenMaterial_permeability_data/)     | Proposed extension providing relative permeability values for a given temperature and incident angle |
-| [`OpenMaterial_permittivity_data`](OpenMaterial_permittivity_data/)     | Proposed extension providing relative permissivity values for a given temperature and incident angle |
-| [`OpenMaterial_material_parameters`](OpenMaterial_material_parameters/) | Proposed extension providing a physically correct description of materials                           |
-| [`OpenMaterial_reference_link`](OpenMaterial_reference_link/)           | Proposed extension enabling referencing and linking of glTF files                                    |
+|:------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------|
+| [`OpenMaterial_asset_info`](OpenMaterial_asset_info/)                   | Proposed extension defining properties for assets                                                              |
+| [`OpenMaterial_conductivity_data`](OpenMaterial_conductivity_data/)     | Proposed extension providing conductivity values for a given temperature and wavelength range                  |
+| [`OpenMaterial_emissivity_data`](OpenMaterial_emissivity_data/)         | Proposed extension providing emissivity coefficient values for a given temperature                             |
+| [`OpenMaterial_ior_data`](OpenMaterial_ior_data/)                       | Proposed extension providing index of refraction values for a given temperature and wavelength range           |
+| [`OpenMaterial_permeability_data`](OpenMaterial_permeability_data/)     | Proposed extension providing relative permeability values for a given temperature, humidity and incident angle |
+| [`OpenMaterial_permittivity_data`](OpenMaterial_permittivity_data/)     | Proposed extension providing relative permissivity values for a given temperature, humidity and incident angle |
+| [`OpenMaterial_material_parameters`](OpenMaterial_material_parameters/) | Proposed extension providing a physically correct description of materials                                     |
+| [`OpenMaterial_reference_link`](OpenMaterial_reference_link/)           | Proposed extension enabling referencing and linking of glTF files                                              |

--- a/materials/AC11DS.gltf
+++ b/materials/AC11DS.gltf
@@ -41,18 +41,18 @@
                         "lambert_emission": 0.0,
                         "subsurface": {
                             "subsurface": false,
-                            "subsurface_thickness": 1E-03
+                            "subsurface_thickness": 0.0
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
 						"coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },

--- a/materials/Concrete_Broomfinish.gltf
+++ b/materials/Concrete_Broomfinish.gltf
@@ -41,18 +41,18 @@
                         "lambert_emission": 0.0,
                         "subsurface": {
                             "subsurface": false,
-                            "subsurface_thickness": -1.0
+                            "subsurface_thickness": 0.0
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
 						"coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },
@@ -90,7 +90,7 @@
                             "lidar"
                         ],
                         "effective_particle_area": -1.0,
-                        "relative_permittivity_uri": "data/Concrete_BF_permittivity.gltf",
+                        "relative_permittivity_uri": "data/Concrete_Broomfinish_permittivity.gltf",
                         "relative_permeability_uri" : "",
                         "conductivity_uri": "",
                         "acoustic_impedance":-1.0,

--- a/materials/Concrete_Plate.gltf
+++ b/materials/Concrete_Plate.gltf
@@ -41,18 +41,18 @@
                         "lambert_emission": 0.0,
                         "subsurface": {
                             "subsurface": false,
-                            "subsurface_thickness": -1.0
+                            "subsurface_thickness": 0.0
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
 						"coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },

--- a/materials/SMA11S.gltf
+++ b/materials/SMA11S.gltf
@@ -41,26 +41,26 @@
                         "lambert_emission": 0.0,
                         "subsurface": {
                             "subsurface": false,
-                            "subsurface_thickness": -1.0
+                            "subsurface_thickness": 0.0
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
 						"coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },
                     "physical_properties": {
                         "refractive_index_uri": "",
-                        "mean_free_path": 1E-06,
-                        "particle_density": 2.7,
-                        "particle_cross_section": 1.00E+0,
+                        "mean_free_path": -1.0,
+                        "particle_density": -1.0,
+                        "particle_cross_section": -1.0,
                         "emissive_coefficient_uri": "",
                         "detection_wavelength_ranges": [
                         {

--- a/materials/SMA8S.gltf
+++ b/materials/SMA8S.gltf
@@ -41,26 +41,26 @@
                         "lambert_emission": 0.0,
                         "subsurface": {
                             "subsurface": false,
-                            "subsurface_thickness": -1.0
+                            "subsurface_thickness": 0.0
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
 						"coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },
                     "physical_properties": {
                         "refractive_index_uri": "",
-                        "mean_free_path": 1E-06,
-                        "particle_density": 2.7,
-                        "particle_cross_section": 1.00E+0,
+                        "mean_free_path": -1.0,
+                        "particle_density": -1.0,
+                        "particle_cross_section": -1.0,
                         "emissive_coefficient_uri": "",
                         "detection_wavelength_ranges": [
                         {

--- a/materials/aluminium.gltf
+++ b/materials/aluminium.gltf
@@ -45,14 +45,14 @@
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
 						"coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },

--- a/materials/data/AC11DS_permittivity.gltf
+++ b/materials/data/AC11DS_permittivity.gltf
@@ -7,16 +7,16 @@
             "OpenMaterial_asset_info": {
                 "asset_type": "material_permittivity",
                 "id": "11a9cf2e-b89c-4571-831b-135ac43d9c11",
-                "title": "relative permittivity AC11DS",
+                "title": "Relative permittivity AC11DS",
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "relative permittivity of asphalt concrete with a maximum grain size of 11mm (AC11DS)",
+                "description": "Relative permittivity of asphalt concrete with a maximum grain size of 11mm (AC11DS)",
                 "creation_date": "2022.01.10. 12:00:00",
                 "sources": [
                     "https://ars.copernicus.org/articles/19/165/2021/"
                 ],
-                "comment": "relative permittivity of asphalt concrete with a maximum grain size of 11mm (AC11DS); data obtained in a radar measurement using a frequency range of 76-81GHz"
+                "comment": "Relative permittivity of asphalt concrete with a maximum grain size of 11mm (AC11DS); data obtained in a radar measurement using a frequency range of 76-81GHz"
             }
         }
     },
@@ -25,9 +25,10 @@
             "data": [
                 {
                     "temperature": 280.0,
+                    "humidity": -1.0,
                     "incident_angle": 0.78,		
                     "permittivity": [
-                        [8.6, -1.0]					
+                        [3.89341e-03, 8.6]					
                     ]
                 }
             ]

--- a/materials/data/Concrete_Broomfinish_permittivity.gltf
+++ b/materials/data/Concrete_Broomfinish_permittivity.gltf
@@ -7,16 +7,16 @@
             "OpenMaterial_asset_info": {
                 "asset_type": "material_permittivity",
                 "id": "91294076-27f8-47bb-bd34-413a2ef2d258",
-                "title": "relative permittivity Concrete_BF",
+                "title": "Relative permittivity Concrete_BF",
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "relative permittivity of conrete roads built in using broomfinish technique  (Concrete_BF)",
+                "description": "Relative permittivity of conrete roads built in using broomfinish technique  (Concrete_BF)",
                 "creation_date": "2022.01.10. 12:00:00",
                 "sources": [
                     "https://ars.copernicus.org/articles/19/165/2021/"
                 ],
-                "comment": "relative permittivity of conrete roads built in using broomfinish technique (Concrete_BF);data obtained in a radar measurement using a frequency range of 76-81GHz"
+                "comment": "Relative permittivity of conrete roads built in using broomfinish technique (Concrete_BF);data obtained in a radar measurement using a frequency range of 76-81GHz"
             }
         }
     },
@@ -25,9 +25,10 @@
             "data": [
                 {
                     "temperature": 280.0,
+                    "humidity": -1.0,
                     "incident_angle": 0.78,				
                     "permittivity": [
-                        [4.34, -1.0]					
+                        [3.89341e-03, 4.34]					
                     ]
                 }
             ]

--- a/materials/data/Concrete_Plate_permittivity.gltf
+++ b/materials/data/Concrete_Plate_permittivity.gltf
@@ -7,16 +7,16 @@
             "OpenMaterial_asset_info": {
                 "asset_type": "material_permittivity",
                 "id": "5e099027-a4b6-4141-9286-6da883814a21",
-                "title": "relative permittivity Concrete_Plate",
+                "title": "Relative permittivity Concrete_Plate",
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "relative permittivity of road surface concrete plates (Concrete_Plate)",
+                "description": "Relative permittivity of road surface concrete plates (Concrete_Plate)",
                 "creation_date": "2022.01.10. 12:00:00",
                 "sources": [
                     "https://ars.copernicus.org/articles/19/165/2021/"
                 ],
-                "comment": "relative permittivity of road surface concrete plates (Concrete_Plate); data obtained in a radar measurement using a frequency range of 76-81GHz"
+                "comment": "Relative permittivity of road surface concrete plates (Concrete_Plate); data obtained in a radar measurement using a frequency range of 76-81GHz"
             }
         }
     },
@@ -25,9 +25,10 @@
             "data": [
                 {
                     "temperature": 280.0,
+                    "humidity": -1.0,
                     "incident_angle": 0.78,					
                     "permittivity": [
-                        [4.64, -1.0]					
+                        [3.89341e-03, 4.64]					
                     ]
                 }
             ]

--- a/materials/data/SMA11S_permittivity.gltf
+++ b/materials/data/SMA11S_permittivity.gltf
@@ -7,16 +7,16 @@
             "OpenMaterial_asset_info": {
                 "asset_type": "material_permittivity",
                 "id": "ddf1707a-f944-43f8-a49d-032bee751c8e",
-                "title": "relative permittivity SMA11S",
+                "title": "Relative permittivity SMA11S",
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "relative permittivity of split mastix asphalt with a maximum grain size of 11mm (SMA11S)",
+                "description": "Relative permittivity of split mastix asphalt with a maximum grain size of 11mm (SMA11S)",
                 "creation_date": "2022.01.10. 12:00:00",
                 "sources": [
                     "https://ars.copernicus.org/articles/19/165/2021/"
                 ],
-                "comment": "relative permittivity of split mastix asphalt with a maximum grain size of 11mm (SMA11S); data obtained in a radar measurement using a frequency range of 76-81GHz"
+                "comment": "Relative permittivity of split mastix asphalt with a maximum grain size of 11mm (SMA11S); data obtained in a radar measurement using a frequency range of 76-81GHz"
             }
         }
     },
@@ -25,9 +25,10 @@
             "data": [
                 {
                     "temperature": 280.0,
+                    "humidity": -1.0,
                     "incident_angle": 0.78,					
                     "permittivity": [
-                        [8.3, -1.0]					
+                        [3.89341e-03, 8.3]					
                     ]
                 }
             ]

--- a/materials/data/SMA8S_permittivity.gltf
+++ b/materials/data/SMA8S_permittivity.gltf
@@ -7,16 +7,16 @@
             "OpenMaterial_asset_info": {
                 "asset_type": "material_permittivity",
                 "id": "e648bb58-7d81-4a79-9f95-f66955560d53",
-                "title": "relative permittivity SMA8S",
+                "title": "Relative permittivity SMA8S",
                 "asset_version": "1",
                 "asset_variation": "1",
                 "creator": "Bayerische Motoren Werke Aktiengesellschaft (BMW AG), Technische Universitaet Muenchen - Professur fuer Hoechstfrequenztechnik",
-                "description": "relative permittivity of split mastix asphalt with a maximum grain size of 8mm (SMA8S)",
+                "description": "Relative permittivity of split mastix asphalt with a maximum grain size of 8mm (SMA8S)",
                 "creation_date": "2022.01.10. 12:00:00",
                 "sources": [
                     "https://ars.copernicus.org/articles/19/165/2021/"
                 ],
-                "comment": "relative permittivity of split mastix asphalt with a maximum grain size of 8mm (SMA8S); data obtained in a radar measurement using a frequency range of 76-81GHz" 
+                "comment": "Relative permittivity of split mastix asphalt with a maximum grain size of 8mm (SMA8S); data obtained in a radar measurement using a frequency range of 76-81GHz" 
             }
         }
     },
@@ -25,9 +25,10 @@
             "data": [
                 {
                     "temperature": 280.0,
+                    "humidity": -1.0,
                     "incident_angle": 0.78,									
                     "permittivity": [
-                        [10.4, -1.0]					
+                        [3.89341e-03, 10.4]					
                     ]
                 }
             ]

--- a/materials/gold.gltf
+++ b/materials/gold.gltf
@@ -45,14 +45,14 @@
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
                         "coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },

--- a/materials/iron.gltf
+++ b/materials/iron.gltf
@@ -45,14 +45,14 @@
                         },
                         "ingredients": [
                             {
-                            "material_ref": "ingredients.gltf",
-                            "order": "order.glft"
+                            "material_ref": "",
+                            "order": ""
                             }
                         ],
                         "coating_materials": [
                             {
                             "layer_thickness": 0.0,
-                            "material_ref": "coating.gltf"
+                            "material_ref": ""
                             }
                         ] 
                     },


### PR DESCRIPTION
Add humidity as parameter to OpenMaterial_permeability_data and OpenMaterial_permittivity_data extensions and all corresponding files.